### PR TITLE
feat: Lifecycle commands (install/update/remove) + self-update detection

### DIFF
--- a/HELP.md
+++ b/HELP.md
@@ -152,8 +152,9 @@ Symlink the command into `~/.local/bin/dotfiles` and check `PATH`. Run as
 
 Pull the latest repo (which **self-updates this script** via the symlink), report
 the tool's commit change (`a1b2c3d → e4f5g6h`), then re-run `deploy` to apply any
-new/changed config symlinks. The one command that brings the whole machine
-current. Must be on `main`.
+new/changed config symlinks. Brings the **tool and configs** current in one step
+(packages are separate — see `pkg sync`). If the pull advanced the tool, the
+deploy phase re-execs the updated tool so it runs the new code. Must be on `main`.
 
 ### `remove`
 

--- a/HELP.md
+++ b/HELP.md
@@ -131,6 +131,36 @@ Then prompts to confirm the push.
 - `--branch` / `-b` — push to a different remote branch
 - `--message` / `-m <msg>` — skip all prompts (commit message + push confirm); one-shot mode
 
+## Lifecycle: install / update / remove
+
+The `dotfiles` command in `~/.local/bin` is a **symlink into this repo**, so
+pulling the repo updates the tool itself transparently. These verbs make that
+lifecycle explicit. (They operate on the **tool**; `deploy` operates on your
+**configs** — two different layers.)
+
+Every other command also does a throttled check (once/day, on `main`, only when
+interactive) and prints a one-line nudge if the repo is behind `origin/main`.
+Disable with `DOTFILES_NO_UPDATE_CHECK=1`.
+
+### `install`
+
+Symlink the command into `~/.local/bin/dotfiles` and check `PATH`. Run as
+`./dotfiles install` from a fresh clone to self-install — this is what
+`install.sh` and `bootstrap.sh` now call under the hood.
+
+### `update`
+
+Pull the latest repo (which **self-updates this script** via the symlink), report
+the tool's commit change (`a1b2c3d → e4f5g6h`), then re-run `deploy` to apply any
+new/changed config symlinks. The one command that brings the whole machine
+current. Must be on `main`.
+
+### `remove`
+
+Remove the `~/.local/bin/dotfiles` command symlink only. Your deployed config
+symlinks and the repo are left intact. Re-install with `<repo>/dotfiles install`.
+(Alias: `uninstall`.)
+
 ### `help`
 
 This page.

--- a/bootstrap.sh
+++ b/bootstrap.sh
@@ -19,27 +19,14 @@ LOCAL_BIN="$HOME/.local/bin"
 echo -e "${BLUE}=== Dotfiles Bootstrap ===${NC}"
 echo
 
-# Step 1: Install dotfiles command
+# Step 1: Install dotfiles command (delegated to the tool itself)
 echo -e "${GREEN}Step 1: Installing dotfiles command...${NC}"
+"$DOTFILES_SCRIPT" install
 
-# Create ~/.local/bin if it doesn't exist
-if [[ ! -d "$LOCAL_BIN" ]]; then
-    mkdir -p "$LOCAL_BIN"
-    echo "Created $LOCAL_BIN"
-fi
-
-# Create symlink to dotfiles script
-if [[ -L "$LOCAL_BIN/dotfiles" ]]; then
-    rm "$LOCAL_BIN/dotfiles"
-fi
-ln -s "$DOTFILES_SCRIPT" "$LOCAL_BIN/dotfiles"
-echo "Created symlink: dotfiles -> $DOTFILES_SCRIPT"
-
-# Check if ~/.local/bin is in PATH
+# Check if ~/.local/bin is in PATH (affects how later steps invoke the command)
 PATH_WARNING=false
 if [[ ":$PATH:" != *":$LOCAL_BIN:"* ]]; then
     PATH_WARNING=true
-    echo -e "${YELLOW}WARNING: $LOCAL_BIN is not in your PATH${NC}"
 fi
 
 echo

--- a/dotfiles
+++ b/dotfiles
@@ -905,12 +905,16 @@ check_for_update() {
     [[ "$(git -C "$DOTFILES_DIR" rev-parse --abbrev-ref HEAD)" == "main" ]] || return 0
 
     local stamp="$HOME/.cache/dotfiles/last-check" now last=0 age
-    mkdir -p "$(dirname "$stamp")"
+    # This runs on the happy path of every command, so it must never abort it:
+    # guard the cache dir (read-only home) and stamp the *attempt* (not just a
+    # successful fetch) so an offline host doesn't re-fetch on every invocation.
+    mkdir -p "$(dirname "$stamp")" 2>/dev/null || return 0
     now="$(date +%s)"
     [[ -f "$stamp" ]] && last="$(date -r "$stamp" +%s 2>/dev/null || echo 0)"
     age=$(( now - last ))
     if (( age >= 86400 )); then
-        git -C "$DOTFILES_DIR" fetch origin main --quiet 2>/dev/null && touch "$stamp"
+        git -C "$DOTFILES_DIR" fetch origin main --quiet 2>/dev/null || true
+        touch "$stamp" 2>/dev/null || true
     fi
 
     local behind
@@ -925,8 +929,9 @@ cmd_install() {
     echo -e "${CYAN}=== Installing dotfiles command ===${NC}"
     echo
     mkdir -p "$LOCAL_BIN"
-    [[ -e "$DOTFILES_CMD_LINK" || -L "$DOTFILES_CMD_LINK" ]] && rm -f "$DOTFILES_CMD_LINK"
-    ln -s "$SCRIPT_PATH" "$DOTFILES_CMD_LINK"
+    # -f replaces any existing link atomically; -n avoids descending into a
+    # symlink-to-directory target. Cleaner than a non-atomic rm + ln.
+    ln -sfn "$SCRIPT_PATH" "$DOTFILES_CMD_LINK"
     log_success "Linked: $DOTFILES_CMD_LINK → $SCRIPT_PATH"
     if [[ ":$PATH:" != *":$LOCAL_BIN:"* ]]; then
         log_warning "$LOCAL_BIN is not on your PATH. Add to your shell config:"
@@ -937,9 +942,13 @@ cmd_install() {
 }
 
 # Update command - pull latest (self-updates the script) then re-deploy configs.
-# Safe to call deploy after the pull rewrites the script: every function body is
-# already parsed into memory before main runs, and the final line is hardened to
-# `main "$@"; exit $?` so no post-update bytes are read from the changed file.
+# Always targets main (the documented contract); no branch override.
+#
+# If the pull actually advanced HEAD, the deploy phase is run by re-exec'ing the
+# freshly-pulled tool (`exec "$SCRIPT_PATH" deploy`) rather than the in-memory
+# cmd_deploy. The running process still holds the OLD deploy logic — re-exec
+# ensures post-update work runs under post-update code (new manifest handling,
+# new configs, etc.), not just that it doesn't crash.
 cmd_update() {
     require_git_remote || exit 1
     echo -e "${CYAN}=== Updating dotfiles ===${NC}"
@@ -947,14 +956,18 @@ cmd_update() {
     local before after
     before="$(git -C "$DOTFILES_DIR" rev-parse --short HEAD 2>/dev/null || echo unknown)"
 
-    cmd_pull "$@"
+    cmd_pull
 
     after="$(git -C "$DOTFILES_DIR" rev-parse --short HEAD 2>/dev/null || echo unknown)"
     if [[ "$before" != "$after" ]]; then
         log_success "Tool updated: $before → $after"
+        echo
+        log_info "Re-executing the updated tool to deploy configs..."
+        exec "$SCRIPT_PATH" deploy
     fi
+
     echo
-    log_info "Re-deploying configs..."
+    log_info "Already up to date — re-deploying configs..."
     cmd_deploy
     echo
     log_success "Update complete."

--- a/dotfiles
+++ b/dotfiles
@@ -879,6 +879,102 @@ cmd_pkg() {
     esac
 }
 
+# ============================================================================
+# Lifecycle (install / update / remove) + self-update detection
+#
+# The `dotfiles` command in ~/.local/bin is a symlink INTO this repo, so a
+# git pull of the repo updates the tool itself transparently. These verbs make
+# that lifecycle explicit:
+#   install — symlink the command into ~/.local/bin (self-install from a clone)
+#   update  — pull (self-updates the script via the symlink) + re-deploy configs
+#   remove  — remove the command symlink (configs and repo are left intact)
+# A lightweight check on every run nudges you when the repo is behind origin.
+# ============================================================================
+
+LOCAL_BIN="$HOME/.local/bin"
+DOTFILES_CMD_LINK="$LOCAL_BIN/dotfiles"
+
+# Non-blocking "you're behind origin" nudge. Skipped on non-tty, when disabled,
+# off-main, or without a usable remote. Network fetch is throttled to once/day
+# via a stamp file so normal commands stay fast and work offline.
+check_for_update() {
+    [[ -t 1 ]] || return 0
+    [[ -n "${DOTFILES_NO_UPDATE_CHECK:-}" ]] && return 0
+    git -C "$DOTFILES_DIR" rev-parse --git-dir &>/dev/null || return 0
+    git -C "$DOTFILES_DIR" remote get-url origin &>/dev/null || return 0
+    [[ "$(git -C "$DOTFILES_DIR" rev-parse --abbrev-ref HEAD)" == "main" ]] || return 0
+
+    local stamp="$HOME/.cache/dotfiles/last-check" now last=0 age
+    mkdir -p "$(dirname "$stamp")"
+    now="$(date +%s)"
+    [[ -f "$stamp" ]] && last="$(date -r "$stamp" +%s 2>/dev/null || echo 0)"
+    age=$(( now - last ))
+    if (( age >= 86400 )); then
+        git -C "$DOTFILES_DIR" fetch origin main --quiet 2>/dev/null && touch "$stamp"
+    fi
+
+    local behind
+    behind="$(git -C "$DOTFILES_DIR" rev-list --count HEAD..origin/main 2>/dev/null || echo 0)"
+    if (( behind > 0 )); then
+        log_warning "dotfiles is $behind commit(s) behind origin/main — run 'dotfiles update' to update the tool and configs."
+    fi
+}
+
+# Install command - symlink this script into ~/.local/bin (self-install).
+cmd_install() {
+    echo -e "${CYAN}=== Installing dotfiles command ===${NC}"
+    echo
+    mkdir -p "$LOCAL_BIN"
+    [[ -e "$DOTFILES_CMD_LINK" || -L "$DOTFILES_CMD_LINK" ]] && rm -f "$DOTFILES_CMD_LINK"
+    ln -s "$SCRIPT_PATH" "$DOTFILES_CMD_LINK"
+    log_success "Linked: $DOTFILES_CMD_LINK → $SCRIPT_PATH"
+    if [[ ":$PATH:" != *":$LOCAL_BIN:"* ]]; then
+        log_warning "$LOCAL_BIN is not on your PATH. Add to your shell config:"
+        echo "    export PATH=\"\$HOME/.local/bin:\$PATH\""
+    fi
+    echo
+    log_info "Next: 'dotfiles deploy' to symlink your configs, or 'dotfiles help'."
+}
+
+# Update command - pull latest (self-updates the script) then re-deploy configs.
+# Safe to call deploy after the pull rewrites the script: every function body is
+# already parsed into memory before main runs, and the final line is hardened to
+# `main "$@"; exit $?` so no post-update bytes are read from the changed file.
+cmd_update() {
+    require_git_remote || exit 1
+    echo -e "${CYAN}=== Updating dotfiles ===${NC}"
+    echo
+    local before after
+    before="$(git -C "$DOTFILES_DIR" rev-parse --short HEAD 2>/dev/null || echo unknown)"
+
+    cmd_pull "$@"
+
+    after="$(git -C "$DOTFILES_DIR" rev-parse --short HEAD 2>/dev/null || echo unknown)"
+    if [[ "$before" != "$after" ]]; then
+        log_success "Tool updated: $before → $after"
+    fi
+    echo
+    log_info "Re-deploying configs..."
+    cmd_deploy
+    echo
+    log_success "Update complete."
+}
+
+# Remove command - uninstall the command symlink only. Leaves deployed config
+# symlinks and the repo untouched (re-install with: <repo>/dotfiles install).
+cmd_remove() {
+    echo -e "${CYAN}=== Removing dotfiles command ===${NC}"
+    echo
+    if [[ -L "$DOTFILES_CMD_LINK" ]]; then
+        rm -f "$DOTFILES_CMD_LINK"
+        log_success "Removed command symlink: $DOTFILES_CMD_LINK"
+        log_info "Your deployed configs and the repo at $DOTFILES_DIR are untouched."
+        log_info "Re-install anytime with: $SCRIPT_PATH install"
+    else
+        log_warning "No dotfiles command symlink at $DOTFILES_CMD_LINK — nothing to remove."
+    fi
+}
+
 # Terse usage - one-line per command. Shown when run with no args.
 cmd_usage() {
     cat << EOF
@@ -907,6 +1003,9 @@ ${YELLOW}Commands:${NC}
     ${GREEN}push${NC} [--branch <b>] [--message <msg>]
                         Commit and push to origin (default branch: main).
                         Use --message (-m) to skip prompts and run in one shot.
+    ${GREEN}install${NC}            Symlink the dotfiles command into ~/.local/bin
+    ${GREEN}update${NC}             Pull latest (self-updates the tool) and re-deploy configs
+    ${GREEN}remove${NC}             Remove the command symlink (configs/repo left intact)
     ${GREEN}help${NC}               Open the full manual (rendered with glow if available)
 EOF
 }
@@ -930,7 +1029,14 @@ main() {
     # No args → terse usage. Explicit `help` → full manual.
     local cmd="${1:-usage}"
     shift || true
-    
+
+    # Nudge if the repo is behind origin — but not for lifecycle/git verbs
+    # (which act on it directly) or the trivial usage/help paths.
+    case "$cmd" in
+        install|update|remove|pull|push|diff|help|--help|-h|usage) ;;
+        *) check_for_update ;;
+    esac
+
     case "$cmd" in
         status)
             cmd_status "$@"
@@ -962,6 +1068,15 @@ main() {
         push)
             cmd_push "$@"
             ;;
+        install)
+            cmd_install "$@"
+            ;;
+        update)
+            cmd_update "$@"
+            ;;
+        remove|uninstall)
+            cmd_remove "$@"
+            ;;
         usage)
             cmd_usage
             ;;
@@ -977,5 +1092,9 @@ main() {
     esac
 }
 
-# Run main function
-main "$@"
+# Run main function.
+# `; exit $?` on the same line is deliberate: pull/update can rewrite this
+# script mid-run, and bash reads scripts lazily by byte offset. Parsing
+# `main "$@"; exit $?` as one line means exit fires from memory, so no bytes
+# are read from the (possibly changed) file after a self-update.
+main "$@"; exit $?

--- a/install.sh
+++ b/install.sh
@@ -1,39 +1,9 @@
 #!/bin/bash
 
-# Install script for dotfiles management tool
+# Thin wrapper — the install logic now lives in the dotfiles tool itself
+# (`dotfiles install`). Kept so existing muscle memory and docs still work.
 
 set -euo pipefail
 
 DOTFILES_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
-DOTFILES_SCRIPT="$DOTFILES_DIR/dotfiles"
-LOCAL_BIN="$HOME/.local/bin"
-
-echo "Installing dotfiles management tool..."
-
-# Create ~/.local/bin if it doesn't exist
-if [[ ! -d "$LOCAL_BIN" ]]; then
-    mkdir -p "$LOCAL_BIN"
-    echo "Created $LOCAL_BIN"
-fi
-
-# Create symlink to dotfiles script
-if [[ -L "$LOCAL_BIN/dotfiles" ]]; then
-    rm "$LOCAL_BIN/dotfiles"
-fi
-
-ln -s "$DOTFILES_SCRIPT" "$LOCAL_BIN/dotfiles"
-echo "Created symlink: $LOCAL_BIN/dotfiles -> $DOTFILES_SCRIPT"
-
-# Check if ~/.local/bin is in PATH
-if [[ ":$PATH:" != *":$LOCAL_BIN:"* ]]; then
-    echo
-    echo "WARNING: $LOCAL_BIN is not in your PATH"
-    echo "Add this line to your shell config (.zshrc or .bashrc):"
-    echo "  export PATH=\"\$HOME/.local/bin:\$PATH\""
-else
-    echo
-    echo "Installation complete! You can now use 'dotfiles' from anywhere."
-fi
-
-echo
-echo "Run 'dotfiles help' to get started."
+exec "$DOTFILES_DIR/dotfiles" install

--- a/readme.md
+++ b/readme.md
@@ -6,23 +6,31 @@ Yes I know it's silly that it's called dotfiles, with a .
 
 ## 🚀 Bootstrap on a New Machine
 
+One-liner (clone, then run the bootstrap that lives in the clone):
+
 ```bash
-# 1. Clone your dotfiles repo
-git clone https://github.com/yourusername/dotfiles.git ~/.dotfiles
-cd ~/.dotfiles
+git clone https://github.com/aaronsb/dotfiles.git ~/.dotfiles && ~/.dotfiles/bootstrap.sh
+```
 
-# 2. Run the bootstrap script (interactive setup)
-./bootstrap.sh
+> Not `curl | bash`: bootstrap **must** run from inside the clone (the
+> `dotfiles` command is a symlink back into the repo), and cloning first gives
+> you a repo you can inspect. Assumes `~/.dotfiles` doesn't already exist.
 
-# 3. Reload your shell
-source ~/.zshrc  # or ~/.bashrc
+Or step by step:
+
+```bash
+git clone https://github.com/aaronsb/dotfiles.git ~/.dotfiles
+~/.dotfiles/bootstrap.sh   # interactive setup
+source ~/.zshrc            # reload your shell
 ```
 
 The bootstrap script will:
-- Install the `dotfiles` command
+- Install the `dotfiles` command (via `dotfiles install`)
 - Show current status
 - Offer to deploy configs (with preview option)
-- Set up everything needed
+
+Already cloned and just need the command on a new shell? Run
+`~/.dotfiles/dotfiles install` directly.
 
 ## 📋 Daily Commands
 
@@ -37,6 +45,8 @@ Since everything deploys as symlinks, editing either `~/.tmux.conf` or
 
 ## 🛠️ All Commands
 
+**Configs (symlink layer)**
+
 | Command | Description | Example |
 |---------|-------------|---------|
 | `status` | Show what's deployed vs available | `dotfiles status` |
@@ -46,13 +56,41 @@ Since everything deploys as symlinks, editing either `~/.tmux.conf` or
 | `disable` | Temporarily disable a config | `dotfiles disable tmux` |
 | `list` | Show all managed configs | `dotfiles list` |
 
+**Sync (git layer)**
+
+| Command | Description | Example |
+|---------|-------------|---------|
+| `diff` | Preview local state vs origin | `dotfiles diff --details` |
+| `pull` | Fast-forward pull from origin | `dotfiles pull` |
+| `push` | Commit + push to origin | `dotfiles push -m "tmux: ..."` |
+
+**Lifecycle (tool layer)**
+
+| Command | Description | Example |
+|---------|-------------|---------|
+| `install` | Symlink the command into `~/.local/bin` | `./dotfiles install` |
+| `update` | Pull latest (self-updates the tool) + re-deploy | `dotfiles update` |
+| `remove` | Remove the command symlink (configs stay) | `dotfiles remove` |
+| `help` | Open the full manual | `dotfiles help` |
+
+**Packages (system layer)**
+
+| Command | Description | Example |
+|---------|-------------|---------|
+| `pkg capture` | Record this host's explicit packages | `dotfiles pkg capture` |
+| `pkg status` | Show package drift (tracked vs installed) | `dotfiles pkg status` |
+| `pkg sync` | Install tracked-but-missing (`--prune` removes extras) | `dotfiles pkg sync` |
+
+Run `dotfiles help` for the full manual.
+
 ## 📁 Directory Structure
 
 ```
 ~/.dotfiles/
-├── dotfiles           # Main management script
-├── bootstrap.sh       # New machine setup
-├── install.sh         # Quick command installer
+├── dotfiles           # Main management script (install/deploy/sync/pkg/...)
+├── bootstrap.sh       # New machine entry point (calls `dotfiles install`)
+├── install.sh         # Thin wrapper → `dotfiles install`
+├── HELP.md            # Full manual (rendered by `dotfiles help`)
 ├── .dotfiles-manifest # Tracking what's managed
 ├── CLAUDE.md          # AI assistant instructions
 ├── readme.md          # This file
@@ -61,8 +99,11 @@ Since everything deploys as symlinks, editing either `~/.tmux.conf` or
 │   └── .tmux.conf    # → ~/.tmux.conf
 ├── zsh/
 │   ├── .zshrc        # → ~/.zshrc
-│   └── .zsh/         # → ~/.zsh (conf.d fragments)
-└── nvim/             # → ~/.config/nvim
+│   └── .zsh/         # → ~/.zsh (conf.d fragments + host.d/ per-host)
+├── oh-my-posh/       # → ~/.config/oh-my-posh/* and ~/.local/bin/posh-theme
+├── nvim/             # → ~/.config/nvim
+└── packages/         # Per-host package lists (pkg subsystem, not symlinked)
+    └── <hostname>/   #   native.txt · aur.txt · flatpak.txt
 ```
 
 ## 💡 Helpful Reminders
@@ -104,15 +145,44 @@ git commit -m "nvim: Add initial neovim configuration
 ```
 
 ### Syncing Changes
-```bash
-# Push your changes
-git push
 
-# On another machine
-git pull
-dotfiles deploy --dry-run  # Preview
-dotfiles deploy --force     # Apply
+The tool wraps git so you don't drop to raw commands:
+
+```bash
+# Push your changes (prompts for a commit message)
+dotfiles push
+dotfiles push -m "tmux: add weather widget"   # one-shot, no prompts
+
+# On another machine — pull + re-deploy in one step
+dotfiles update            # self-updates the tool, then deploys configs
+
+# Or preview/pull manually
+dotfiles diff --details    # what would pull/push do?
+dotfiles pull              # fast-forward only
+dotfiles deploy            # symlink any new configs
 ```
+
+Because the `dotfiles` command is itself a symlink into the repo, `pull`/`update`
+upgrade the tool transparently — `update` reports the version bump so it's not a
+silent change. Every command also nudges you when the repo is behind origin
+(disable with `DOTFILES_NO_UPDATE_CHECK=1`).
+
+### Tracking Packages (Arch family)
+
+Record what's explicitly installed per host, so a rebuild is reproducible:
+
+```bash
+dotfiles pkg status        # drift: tracked vs actually installed
+dotfiles pkg capture       # write live state → packages/<host>/*.txt
+dotfiles push              # commit the lists
+
+# On a new machine, after pulling:
+dotfiles pkg sync          # install tracked-but-missing (additive)
+dotfiles pkg sync --prune  # also remove untracked (sharper edge)
+```
+
+Sources (native/AUR/flatpak) absent on a host are skipped, not errored. See
+`dotfiles help` for details.
 
 ## 🔧 How It Works
 


### PR DESCRIPTION
## What

Makes the `dotfiles` tool self-managing and its self-update legible.

- **`install`** — symlink the command into `~/.local/bin` (self-install from a clone). `install.sh` and `bootstrap.sh` now delegate to it instead of duplicating the symlink logic.
- **`update`** — `pull` (which self-updates this script via the symlink) → report the tool's commit bump → re-`deploy` configs. One command to bring a machine current.
- **`remove`** — remove the command symlink only; configs and repo untouched.
- **Auto-check** — every other command does a throttled (once/day, `main`-only, interactive-only) check and nudges when the repo is behind `origin/main`. Opt out with `DOTFILES_NO_UPDATE_CHECK=1`.

## Why

`dotfiles pull` already self-updated the tool (the command is a symlink into the repo) — but invisibly. These verbs + the nudge make updates explicit and remove the dependency on external bootstrap/install scripts.

## Notable

- **Self-update hardening:** final line is now `main "$@"; exit $?`. Bash reads scripts lazily by byte offset, so a `pull`/`update` that rewrites this file mid-run could make bash execute stray bytes; parsing exit on the same line as main closes that.
- Tool layer (`install`/`update`/`remove`) is kept distinct from the config layer (`deploy`) in code and docs.
- `install.sh` → thin wrapper; `bootstrap.sh` → calls `dotfiles install`.

## Docs

README was stale (predated pkg/diff/pull/push + lifecycle); refreshed with the clone+bootstrap one-liner, layer-grouped command tables, a rewritten sync section using the tool's own wrappers, a package-tracking section, and a corrected directory tree. HELP.md gains the lifecycle section.

## Testing

- ✅ `install`, `remove`, reinstall round-trip; symlink restored/valid.
- ✅ `update` off-`main` refuses via the pull guard and does **not** deploy.
- ✅ auto-check stays silent off-`main`.
- ⚠️ The "behind origin → nudge" path and full `update` (pull+deploy) on `main` will first run for real after merge.

## Follow-up

The script is now ~1080 lines. A `lib/` split (extracting `pkg` and lifecycle into sourced modules, with the installer carrying the dir) is next, on its own `refactor/` branch — pure restructuring, no behavior change.