### PR TITLE
feat(tmux): forward clipboard to origin host via OSC 52

### DIFF
--- a/tmux/.tmux.conf
+++ b/tmux/.tmux.conf
@@ -14,6 +14,17 @@ set -g mouse on
 set -g default-terminal "tmux-256color"
 set -ga terminal-overrides ",xterm-256color:RGB,*256col*:RGB,fbterm:RGB"
 
+# Clipboard: forward copies to the *originating* host's system clipboard via
+# OSC 52. When copying inside a remote session (e.g. 'smux cube' from north),
+# tmux emits an escape sequence that rides back over SSH stdout as plain
+# terminal bytes — no xclip/wl-copy on the remote, no X forwarding, no
+# back-channel. set-clipboard on also makes a *local* (outer) tmux forward an
+# inner session's OSC 52 onward instead of swallowing it, so nested
+# tmux-in-tmux still reaches the real terminal. clipboard terminal-feature
+# tells tmux the outer terminal accepts the OSC 52 clipboard cap (tmux 3.2+).
+set -s set-clipboard on
+set -as terminal-features ',xterm-256color:clipboard'
+
 # ========================================
 # BASIC SETTINGS
 # ========================================


### PR DESCRIPTION
## Summary
- Enables OSC 52 clipboard forwarding so copies inside a remote tmux session (e.g. `smux cube` from north) reach the **originating** host's system clipboard over SSH — no `xclip`/`wl-copy` on the remote, no X forwarding.
- Fixes the mouse-capture trap where a remote drag-selection only landed in the remote paste buffer and never came home.
- `set-clipboard on` also forwards a nested inner session's OSC 52 through a local outer tmux, so tmux-in-tmux still reaches the terminal. Symlink-deployed → consistent across all hosts.

## Test plan
- `prefix : source-file ~/.tmux.conf` in a live session; confirm `tmux show -s set-clipboard` → `on`.
- From north, `smux` to a remote host, drag-select text, confirm it pastes into north's local clipboard.
- Requires the local terminal emulator to permit OSC 52 writes (most modern ones do; some need a toggle).