### PR TITLE
manifest: waydesk spec — add util-linux, reflect session management

### DIFF
--- a/.dotfiles-manifest.toml
+++ b/.dotfiles-manifest.toml
@@ -120,14 +120,14 @@ spec.requires.packages = ["polkit"]
 name = "waydesk"
 path = "waydesk/waydesk"
 target = ".local/bin/waydesk"
-why = "One-shot launcher for a remote Wayland desktop over waypipe+ssh, forked to run detached. Lets any machine reach another (north<->slab<->cube) and bring up a nested Plasma/sway session without relay or STUN — LAN/VPN only."
-spec.summary  = "Detached remote Wayland desktop (nested Plasma/sway) over waypipe+ssh; LAN/VPN, no relay. Needs a live local Wayland session to display into."
+why = "Launcher and session manager for a remote Wayland desktop over waypipe+ssh: brings up a detached nested Plasma/sway session on another host (north<->slab<->cube) without relay or STUN (LAN/VPN), and tracks it on both ends so list/stop tear the whole session down cleanly."
+spec.summary  = "Detached, tracked remote Wayland desktop (nested Plasma/sway) over waypipe+ssh; list/stop manage sessions. LAN/VPN, no relay. Needs a live local Wayland session to display into."
 spec.concern  = "remote-desktop"
 spec.platform = "linux-wayland"
-spec.tags     = ["waypipe", "ssh", "plasma"]
+spec.tags     = ["waypipe", "ssh", "plasma", "sway"]
 spec.provides = ["waydesk"]
 spec.depends  = ["polkitctl"]
-spec.requires.packages = ["waypipe", "openssh"]
+spec.requires.packages = ["waypipe", "openssh", "util-linux"]
 
 [profiles.north]
 


### PR DESCRIPTION
Small consistency fix to the `waydesk` manifest entry:

- **`requires.packages` += `util-linux`** — the preflight checks `setsid` (from util-linux) but the spec didn't declare it.
- **Reconcile drift** — `why`/`summary` now describe session management (`list`/`stop`, both-end teardown) instead of "one-shot launcher"; `tags` gains `sway`.

Verified: manifest parses; `dotfiles show waydesk` renders correctly.

https://claude.ai/code/session_01GN4FG1ZphoF5ihYC4ho4NR